### PR TITLE
Create .gitattributes for Linguist-configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Have Linguist, which Github uses to scan a repository for languages used,
+# see YAML as a non-documentation language
+# Note: this is a Github- and decorative change only. Doesn't affect functionality in any way.
+*.yml linguist-detectable=true
+*.yml linguist-language=YAML


### PR DESCRIPTION
> Have Linguist see YAML as a programming language, creating a more realistic view of the languages used in this project. This change is _purely cosmetic_.

Ich hatte beim Anschauen-und-Verstehen des Setups hier gesehen, dass hauptsächlich YAML- und Jinja-Dateien verwendet wurden, Github die YAML-Dateien aber 'nicht erkennt' bzw. nicht als Sprache zählt.
Das liegt wohl daran, dass Linguist, das Tool von Github, welches die Repos nach Sprachen scannt, YAML nicht zählt, weil es standardmäßig als Konfigurationssprache eingestuft wird.

Ich finde, in diesem Repo sind die YAML-Dateien sehr relevant, und es wäre nett, die Aufteilung korrekter zu sehen, vor allen Dingen für neue Leute, um das Repo auf einen Blick besser einschätzen zu können.

Es ist ein *rein kosmetisch* und betrifft die Funktionsweise des Projektes nicht.  

Es dreht sich um dieses Diagramm hier:
![image](https://github.com/user-attachments/assets/655d8b1c-578d-4d28-b831-6b32b2a47d5f)

Nach Änderung:
![image](https://github.com/user-attachments/assets/2d1a0e89-f1a3-454b-8692-d50138d63723)