### PR TITLE
Restore commands ins Wiki

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Have Linguist, which Github uses to scan a repository for languages used,
+# see YAML as a non-documentation language
+# Note: this is a Github- and decorative change only. Doesn't affect functionality in any way.
+*.yml linguist-detectable=true
+*.yml linguist-language=YAML

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Installation:  
 
+## Backup- und Restore-Prozess
+Siehe [Wiki-Artikel](https://wiki.makerspace-gt.de/de/IT-Infrastruktur/Backup-selfhosted).
+
 ## ToDo
 
 - [ ] discourse

--- a/deployment.yml
+++ b/deployment.yml
@@ -69,30 +69,9 @@
       vars:
         SERVICES_ZAMMAD_LABELS_TRAEFIK_HOST: "`helpdesk.makerspace-gt.de`"
 
-      # # Restore Zammad Backup
-      # # https://github.com/DoTheEvo/selfhosted-apps-docker/tree/master/zammad#backup-and-restore
-      # # https://restic.readthedocs.io/en/stable/050_restore.html#
-      # # https://docs.zammad.org/en/latest/install/docker-compose.html#how-to-run-commands-in-the-stack
-
-      # docker compose --project-directory /opt/containers/zammad-stack down --remove-orphans 
-      # docker exec resticker restic restore 74c4f304:/mnt/volumes/zammad --include zammad_production.pg_dump --target /mnt/volumes/zammad
-      # docker compose --project-directory /opt/containers/zammad-stack up -d zammad-postgresql
-      # docker compose --project-directory /opt/containers/zammad-stack exec zammad-postgresql bash -c "dropdb zammad_production -U zammad"
-      # docker compose --project-directory /opt/containers/zammad-stack exec zammad-postgresql bash -c "createdb zammad_production -U zammad"
-      # docker compose --project-directory /opt/containers/zammad-stack exec zammad-postgresql bash -c "psql -U zammad zammad_production < /var/tmp/zammad/zammad_production.pg_dump"
-      # docker compose --project-directory /opt/containers/zammad-stack up -d --force-recreate
-      # docker compose --project-directory /opt/containers/zammad-stack run --rm zammad-railsserver rake zammad:searchindex:rebuild
-
     - role: roles/vaultwarden
       vars:
         SERVICES_VAULTWARDEN_ENVIRONMENT_DOMAIN: "vault.makerspace-gt.de"
-
-      # # Restore Vaultwarden Backup
-      # # https://restic.readthedocs.io/en/stable/050_restore.html#
-
-      # docker compose --project-directory /opt/containers/vaultwarden down --remove-orphans 
-      # docker exec resticker restic restore a394d8e5:/mnt/volumes/vaultwarden --target /mnt/volumes/vaultwarden
-      # docker compose --project-directory /opt/containers/vaultwarden up -d --force-recreate
 
     - role: roles/nextcloud-stack
       vars:
@@ -177,32 +156,8 @@
       vars:
         SERVICES_LABELS_TRAEFIK_HOST: "todo.makerspace-gt.de"
 
-        # # Restore Vikunja Backup
-        # # https://vikunja.io/docs/what-to-backup
-        # # https://www.postgresql.org/docs/current/backup-dump.html
-        # # https://restic.readthedocs.io/en/stable/050_restore.html#
-
-        # docker compose --project-directory /opt/containers/vikunja-stack stop vikunja
-        # docker exec resticker restic restore e7947dde:/mnt/volumes/vikunja --target /mnt/volumes/vikunja
-        # docker compose --project-directory /opt/containers/vikunja-stack exec db bash -c "dropdb vikunja -U vikunja"
-        # docker compose --project-directory /opt/containers/vikunja-stack exec db bash -c "createdb vikunja -U vikunja"
-        # docker compose --project-directory /opt/containers/vikunja-stack exec db bash -c "psql -U vikunja vikunja < /var/tmp/vikunja.pg_dump"
-        # docker compose --project-directory /opt/containers/vikunja-stack up -d --force-recreate
-
     - role: roles/wikijs-stack
       vars:
         SERVICES_WIKIJS_LABELS_TRAEFIK_HOST: "`wiki.makerspace-gt.de`"
-
-        # # Restore Wiki.js Backup
-        # # https://docs.requarks.io/install/transfer
-        # # https://www.postgresql.org/docs/current/backup-dump.html
-        # # https://restic.readthedocs.io/en/stable/050_restore.html#
-
-        # docker compose --project-directory /opt/containers/wikijs-stack stop wikijs
-        # docker exec resticker restic restore 0941e370:/mnt/volumes/wikijs --include wikijs.pg_dump --target /mnt/volumes/wikijs
-        # docker compose --project-directory /opt/containers/wikijs-stack exec wikijs-postgres bash -c "dropdb wikijs -U wikijs"
-        # docker compose --project-directory /opt/containers/wikijs-stack exec wikijs-postgres bash -c "createdb wikijs -U wikijs"
-        # docker compose --project-directory /opt/containers/wikijs-stack exec wikijs-postgres bash -c "psql -U wikijs wikijs < /var/tmp/wikijs.pg_dump"
-        # docker compose --project-directory /opt/containers/wikijs-stack up -d --force-recreate
 
     - role: roles/resticker-stack

--- a/unstable.yml
+++ b/unstable.yml
@@ -66,30 +66,9 @@
 
     # - role: roles/zammad-stack
 
-        # # Restore Zammad Backup
-        # # https://github.com/DoTheEvo/selfhosted-apps-docker/tree/master/zammad#backup-and-restore
-        # # https://restic.readthedocs.io/en/stable/050_restore.html#
-        # # https://docs.zammad.org/en/latest/install/docker-compose.html#how-to-run-commands-in-the-stack
-
-        # docker compose --project-directory /opt/containers/zammad-stack down --remove-orphans 
-        # docker exec resticker restic restore 74c4f304 --target /
-        # docker compose --project-directory /opt/containers/zammad-stack up -d zammad-postgresql
-        # docker compose --project-directory /opt/containers/zammad-stack exec zammad-postgresql bash -c "dropdb zammad_production -U zammad"
-        # docker compose --project-directory /opt/containers/zammad-stack exec zammad-postgresql bash -c "createdb zammad_production -U zammad"
-        # docker compose --project-directory /opt/containers/zammad-stack exec zammad-postgresql bash -c "psql -U zammad zammad_production < /var/tmp/zammad/zammad_production.pg_dump"
-        # docker compose --project-directory /opt/containers/zammad-stack up -d --force-recreate
-        # docker compose --project-directory /opt/containers/zammad-stack run --rm zammad-railsserver rake zammad:searchindex:rebuild
-
     # - role: roles/vaultwarden
     #   vars:
     #     SERVICES_VAULTWARDEN_ENVIRONMENT_DOMAIN: "bitwarden.makerspace-gt.de"
-
-        # # Restore Vaultwarden Backup
-        # # https://restic.readthedocs.io/en/stable/050_restore.html#
-
-        # docker compose --project-directory /opt/containers/vaultwarden down --remove-orphans 
-        # docker exec resticker restic restore a394d8e5:/mnt/volumes/vaultwarden --target /mnt/volumes/vaultwarden
-        # docker compose --project-directory /opt/containers/vaultwarden up -d --force-recreate
 
     # - role: roles/nextcloud-stack
     #   vars:
@@ -173,19 +152,5 @@
     # - role: roles/wikijs-stack
     #   vars:
     #     SERVICES_WIKIJS_LABELS_TRAEFIK_HOST: "`wiki.makerspace-gt.de`"
-
-        # # Transfer wiki.js
-        # # https://docs.requarks.io/install/transfer
-        # # https://www.postgresql.org/docs/current/backup-dump.html
-        # root@discovery:~# cd /var/docker/wiki.js/
-        # root@discovery:/var/docker/wiki.js# docker-compose stop wiki 
-        # root@discovery:~# docker exec wikijs_db_1 pg_dump wiki -U wikijs > wikibackup.db
-
-        # root@wasdus:~# cd /opt/containers/wikijs-stack/
-        # root@wasdus:/opt/containers/wikijs-stack# docker compose stop wikijs
-        # root@wasdus:/opt/containers/wikijs-stack# docker compose exec wikijs-postgres dropdb -U wikijs wikijs
-        # root@wasdus:/opt/containers/wikijs-stack# docker compose exec wikijs-postgres createdb -U wikijs wikijs
-        # root@wasdus:/opt/containers/wikijs-stack# cat wikibackup.dump | docker exec -i wikijs-stack-wikijs-postgres-1 psql -U wikijs wikijs
-        # root@wasdus:/opt/containers/wikijs-stack# docker compose up -d --force-recreate 
 
     - role: roles/resticker-stack


### PR DESCRIPTION
Entfernen der Restore-Anweisungen aus den Playbook-Dateien; sind jetzt in [diesem Wiki-Artikel](https://wiki.makerspace-gt.de/de/IT-Infrastruktur/Backup-selfhosted) zu finden. 
Die Backup-Prozedur, definiert in der [resticker-stack](https://github.com/makerspace-gt/docker-compose-server/tree/main/roles/resticker-stack)-role, wird auch erläutert. 